### PR TITLE
Add function to send text message using Twilio API

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,0 +1,3 @@
+{:twilio-account-sid "your_account_sid"
+ :twilio-auth-token "your_auth_token"
+ :twilio-from-number "your_twilio_number"}

--- a/src/behave_tree/twilio.clj
+++ b/src/behave_tree/twilio.clj
@@ -1,0 +1,23 @@
+(ns behave-tree.twilio
+  (:require [clj-http.client :as client]
+            [clojure.tools.logging :as log]
+            [behave-tree.config :as cfg]))
+
+(defn send-text-message
+  "Sends a text message using the Twilio API."
+  [to-number message]
+  (let [{:keys [twilio-account-sid twilio-auth-token twilio-from-number]} (:twilio (cfg/get-config))
+        url (str "https://api.twilio.com/2010-04-01/Accounts/" twilio-account-sid "/Messages.json")
+        auth [twilio-account-sid twilio-auth-token]
+        params {:from twilio-from-number
+                :to to-number
+                :body message}]
+    (try
+      (let [response (client/post url {:basic-auth auth
+                                       :form-params params
+                                       :as :json})]
+        (log/info (str "Message sent: " (:body response)))
+        (:body response))
+      (catch Exception e
+        (log/error e "Error sending text message")
+        {:status "error"}))))

--- a/test/behave_tree/twilio_test.clj
+++ b/test/behave_tree/twilio_test.clj
@@ -1,0 +1,21 @@
+(ns behave-tree.twilio-test
+  (:require [clojure.test :refer :all]
+            [behave-tree.twilio :as twilio]
+            [clj-http.client :as client]))
+
+(deftest test-send-text-message
+  (let [dummy-response {:body {:status "queued"}}
+        dummy-to-number "+1234567890"
+        dummy-message "Test message"]
+    (with-redefs [client/post (fn [url opts]
+                                (is (= "https://api.twilio.com/2010-04-01/Accounts/your_account_sid/Messages.json" url))
+                                (is (= {:basic-auth ["your_account_sid" "your_auth_token"]
+                                        :form-params {:from "your_twilio_number"
+                                                      :to dummy-to-number
+                                                      :body dummy-message}
+                                        :as :json} opts))
+                                dummy-response)]
+      (is (= {:status "queued"} (twilio/send-text-message dummy-to-number dummy-message))))))
+
+(comment
+  (clojure.test/run-tests))


### PR DESCRIPTION
Add functionality to send text messages using the Twilio API.

* Add `send-text-message` function in `src/behave_tree/twilio.clj` to send a text message using the Twilio API.
* Add Twilio configuration (account SID, auth token, from number) to `resources/config.edn`.
* Add test for `send-text-message` function in `test/behave_tree/twilio_test.clj`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pdmct/behaviour-trees-example/pull/4?shareId=207fbff6-62cf-4b4c-87ac-285112b0f031).